### PR TITLE
Refactored realm and nonce detection

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -24,8 +24,8 @@ class AxiosDigestAuth {
             ++this.count;
             const nonceCount = ('00000000' + this.count).slice(-8);
             const cnonce = crypto.randomBytes(24).toString('hex');
-            const realm = authDetails[0][1].replace(/"/g, '');
-            const nonce = authDetails[2][1].replace(/"/g, '');
+            const realm = authDetails.find(el => el[0].toLowerCase().indexOf("realm") > -1)[1].replace(/"/g, '');
+            const nonce = authDetails.find(el => el[0].toLowerCase().indexOf("nonce") > -1)[1].replace(/"/g, '');
             const ha1 = crypto.createHash('md5').update(`${this.username}:${realm}:${this.password}`).digest('hex');
             const path = url.parse(opts.url).pathname;
             const ha2 = crypto.createHash('md5').update(`${(_a = opts.method) !== null && _a !== void 0 ? _a : "GET"}:${path}`).digest('hex');

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,8 @@ export default class AxiosDigestAuth {
       ++this.count;
       const nonceCount = ('00000000' + this.count).slice(-8);
       const cnonce = crypto.randomBytes(24).toString('hex');
-      const realm = authDetails[0][1].replace(/"/g, '');
-      const nonce = authDetails[2][1].replace(/"/g, '');
+      const realm = authDetails.find(el => el[0].toLowerCase().indexOf("realm") > -1)[1].replace(/"/g, '');
+      const nonce = authDetails.find(el => el[0].toLowerCase().indexOf("nonce") > -1)[1].replace(/"/g, '');
       const ha1 = crypto.createHash('md5').update(`${this.username}:${realm}:${this.password}`).digest('hex');
       const path = url.parse(opts.url!).pathname;
       const ha2 = crypto.createHash('md5').update(`${opts.method ?? "GET"}:${path}`).digest('hex');


### PR DESCRIPTION
This fixes an issue where the realm isn't selected properly for this WWW-Authenticate header which results in authentication failing: Digest qop="auth", realm="thermostat", nonce="1612605593"